### PR TITLE
Fixes to urllib changes

### DIFF
--- a/data/download_data.py
+++ b/data/download_data.py
@@ -1,6 +1,6 @@
 import os
 #import zipfile
-import urllib
+import urllib.request
 import tarfile
 import argparse
 
@@ -21,7 +21,7 @@ def download_dataset(source_url, target_dir, target_file):
         print('downloading ... %d%%' % round(((downloaded*100.0) / total_size)))
 
     print('downloading ... ')
-    urllib.urlretrieve(source_url, filename=target_file, reporthook=show_progress)
+    urllib.request.urlretrieve(source_url, filename=target_file, reporthook=show_progress)
     print('downloading ... done')
 
     print('extracting ...')

--- a/models/download_models.py
+++ b/models/download_models.py
@@ -1,6 +1,6 @@
 import os
 #import zipfile
-import urllib
+import urllib.request
 import tarfile
 import argparse
 
@@ -21,7 +21,7 @@ def download_model(source_url, target_dir, target_file):
         print('downloading ... %d%%' % round(((downloaded*100.0) / total_size)))
 
     print('downloading ... ')
-    urllib.urlretrieve(source_url, filename=target_file, reporthook=show_progress)
+    urllib.request.urlretrieve(source_url, filename=target_file, reporthook=show_progress)
     print('downloading ... done')
 
     print('extracting ...')


### PR DESCRIPTION
The previous code was causing an error: AttributeError: 'module' object has no attribute 'urlretrieve'. This is because in Python 3 urllib.urlretrieve has been replaced exactly with urllib.request.urlretrieve. This change was made in the following 2 commits.

See issue at: https://stackoverflow.com/questions/17960942/attributeerror-module-object-has-no-attribute-urlretrieve
